### PR TITLE
Header fix for Firefox.

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -84,7 +84,7 @@ section {
 }
 
 #top {
-  padding: 20px 0;
+  padding: 20px 0 15px;
   background-color: #fff;
 
   h1 {


### PR DESCRIPTION
Congratulations, guys! Hope you'll get enough support from the community.

Though, for some reason there's a tiny overlap between #top block and the next one in Firefox:
![header](http://i.minus.com/isTErgxzcKY46.png)

Quick fix with reducing bottom padding makes the page perfect. Everything moves up by 5px up in chrome, but layout still looks ok.
