### PR TITLE
Fixed ringtone-link.

### DIFF
--- a/public/email.html
+++ b/public/email.html
@@ -33,7 +33,7 @@
       </p>
       <ul class="features">
 <li>3 cool Travis CI stickers<sup>1</sup>.</li>
-        <li>Access to the <a href="http://support.travis-ci.org/profile/ringtones">ringtones and sounds</a> collection.</li>
+        <li>Access to the <a href="http://love.travis-ci.org/profile/ringtones">ringtones and sounds</a> collection.</li>
         <li>A personal note from the Travis CI team.</li>
         <li>You get on the waiting list for Travis CI pro private beta access<sup>2</sup>.</li>
         <li>USD 200 worth of credit for your future Travis CI pro account.</li>


### PR DESCRIPTION
Hey folks. The link to the ringtones in my »thank you« email was wrong. 
Probably just a typo. ;) 
